### PR TITLE
Reduce size of social media icons

### DIFF
--- a/style.css
+++ b/style.css
@@ -165,8 +165,8 @@ h1 {
 }
 
 .social-icons img {
-    width: 40px;
-    height: 40px;
+    width: 20px;
+    height: 20px;
 }
 
 /* Forms */


### PR DESCRIPTION
## Summary
- tweak `.social-icons img` so icons use 20px dimensions

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_68411672caa8832785937f27dc5fe0de